### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ An MCP server designed to facilitate interaction between Large Language Models (
 
 This project contains various tools that interact with the BoldSign API to manage templates and documents for your e-signature.
 
+<a href="https://glama.ai/mcp/servers/@boldsign/boldsign-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@boldsign/boldsign-mcp/badge" alt="boldsign MCP server" />
+</a>
+
 ## Prerequisites
 
 Before you begin, ensure you have the following installed and set up:


### PR DESCRIPTION
This PR adds a badge for the [boldsign](https://glama.ai/mcp/servers/@boldsign/boldsign-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@boldsign/boldsign-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@boldsign/boldsign-mcp/badge" alt="boldsign MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.