### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/boldsign/boldsign-mcp/security/code-scanning/3](https://github.com/boldsign/boldsign-mcp/security/code-scanning/3)

To address the issue, add a `permissions` block to the workflow to explicitly set the minimum permissions required for the job. In this case, the workflow performs operations such as checking out code, setting up Node.js, installing dependencies, and running Prettier and build commands. None of these operations require write permissions, so the `contents: read` permission is sufficient. This block will restrict the `GITHUB_TOKEN` to read-only access to repository contents.

The `permissions` block should be added either at the root level of the workflow (to apply to all jobs) or within the `build` job itself.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
