### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generate-pack.yml
+++ b/.github/workflows/generate-pack.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  actions: write
 name: Generate package
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/boldsign/boldsign-mcp/security/code-scanning/2](https://github.com/boldsign/boldsign-mcp/security/code-scanning/2)

To fix the problem, we need to add the `permissions` key to the workflow. Since the workflow involves reading repository contents and uploading an artifact, we will apply the least privilege by setting `contents: read` and `actions: write`. Adding the `permissions` block at the root level ensures that all jobs inherit these permissions unless explicitly overridden.

The changes will be made to the `.github/workflows/generate-pack.yml` file. Specifically, the `permissions` block will be added after the `name` key, defining minimal privileges for the entire workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
