### PR TITLE
Fix the null exception in the no-content endpoint responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@boldsign/mcp",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@boldsign/mcp",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@boldsign/mcp",
-  "version": "0.0.3",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@boldsign/mcp",
-      "version": "0.0.3",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/src/tools/documentsTools/revokeDocument.ts
+++ b/src/tools/documentsTools/revokeDocument.ts
@@ -40,12 +40,12 @@ async function revokeDocumentHandler(payload: RevokeDocumentSchemaType): Promise
     const revokeDocumentRequest: RevokeDocument = new RevokeDocument();
     revokeDocumentRequest.message = payload.message;
     revokeDocumentRequest.onBehalfOf = payload.onBehalfOf;
-    const documentResponse: returnTypeI = await documentApi.revokeDocument(
+    const response: returnTypeI = await documentApi.revokeDocument(
       payload.documentId,
       revokeDocumentRequest,
     );
     return handleMcpResponse({
-      data: documentResponse.response.data,
+      data: response,
     });
   } catch (error: any) {
     return handleMcpError(error);

--- a/src/tools/documentsTools/revokeDocument.ts
+++ b/src/tools/documentsTools/revokeDocument.ts
@@ -40,12 +40,12 @@ async function revokeDocumentHandler(payload: RevokeDocumentSchemaType): Promise
     const revokeDocumentRequest: RevokeDocument = new RevokeDocument();
     revokeDocumentRequest.message = payload.message;
     revokeDocumentRequest.onBehalfOf = payload.onBehalfOf;
-    const response: returnTypeI = await documentApi.revokeDocument(
+    const documentResponse: returnTypeI = await documentApi.revokeDocument(
       payload.documentId,
       revokeDocumentRequest,
     );
     return handleMcpResponse({
-      data: response,
+      data: documentResponse?.response?.data ?? documentResponse,
     });
   } catch (error: any) {
     return handleMcpError(error);

--- a/src/tools/documentsTools/revokeDocument.ts
+++ b/src/tools/documentsTools/revokeDocument.ts
@@ -11,10 +11,9 @@ const RevokeDocumentSchema = z.object({
     'Required. The unique identifier (ID) of the document to revoke. This can be obtained from the list documents tool.',
   ),
   message: z.string().describe('The exact reason for performing a revoke action.'),
-  onBehalfOf: z
-    .string()
-    .email()
-    .describe('Email address of on-behalf sender.')
+  onBehalfOf: commonSchema.EmailSchema
+    .optional()
+    .nullable()
     .describe(
       'Optional. Email address of the sender when creating a document on their behalf. This email can be retrieved from the `behalfOf` property in the get document or list documents tool.',
     ),

--- a/src/tools/documentsTools/revokeDocument.ts
+++ b/src/tools/documentsTools/revokeDocument.ts
@@ -11,8 +11,7 @@ const RevokeDocumentSchema = z.object({
     'Required. The unique identifier (ID) of the document to revoke. This can be obtained from the list documents tool.',
   ),
   message: z.string().describe('The exact reason for performing a revoke action.'),
-  onBehalfOf: commonSchema.EmailSchema
-    .optional()
+  onBehalfOf: commonSchema.EmailSchema.optional()
     .nullable()
     .describe(
       'Optional. Email address of the sender when creating a document on their behalf. This email can be retrieved from the `behalfOf` property in the get document or list documents tool.',

--- a/src/tools/documentsTools/sendReminderForDocumentSign.ts
+++ b/src/tools/documentsTools/sendReminderForDocumentSign.ts
@@ -51,13 +51,13 @@ async function sendReminderForDocumentSignHandler(
     const reminderMessage: ReminderMessage = new ReminderMessage();
     reminderMessage.message = payload.message ?? undefined;
     reminderMessage.onBehalfOf = payload.onBehalfOf ?? undefined;
-    const documentResponse: returnTypeI = await documentApi.remindDocument(
+    const response: returnTypeI = await documentApi.remindDocument(
       payload.documentId,
       payload.receiverEmails ?? undefined,
       reminderMessage,
     );
     return handleMcpResponse({
-      data: documentResponse.response.data,
+      data: response,
     });
   } catch (error: any) {
     return handleMcpError(error);

--- a/src/tools/documentsTools/sendReminderForDocumentSign.ts
+++ b/src/tools/documentsTools/sendReminderForDocumentSign.ts
@@ -15,12 +15,13 @@ const SendReminderForDocumentSignSchema = z.object({
     .optional()
     .nullable()
     .describe(
-      'Optional. One or more signer email addresses to send reminders for pending signatures. If multiple signers are required to sign the document, specify their email addresses. If there is not emails provided, it will send reminder to all pending signers.',
+      'Optional. One or more signer email addresses to send reminders for pending signatures. If multiple signers are required to sign the document, specify their email addresses. If there is not emails provided, it will send reminder to all pending signers. The signers of a document can be obtained from the document-properties tool, using the documentId.',
     ),
   message: commonSchema.OptionalStringSchema.describe(
     'Optional. Message to be sent in the reminder email. If not provided, the system will use a default reminder message.',
   ),
-  onBehalfOf: commonSchema.EmailSchema.optional()
+  onBehalfOf: commonSchema.EmailSchema
+    .optional()
     .nullable()
     .describe(
       'Optional. Email address of the sender when creating a document on their behalf. This email can be retrieved from the `behalfOf` property in the get document or list documents tool.',

--- a/src/tools/documentsTools/sendReminderForDocumentSign.ts
+++ b/src/tools/documentsTools/sendReminderForDocumentSign.ts
@@ -51,13 +51,13 @@ async function sendReminderForDocumentSignHandler(
     const reminderMessage: ReminderMessage = new ReminderMessage();
     reminderMessage.message = payload.message ?? undefined;
     reminderMessage.onBehalfOf = payload.onBehalfOf ?? undefined;
-    const response: returnTypeI = await documentApi.remindDocument(
+    const documentResponse: returnTypeI = await documentApi.remindDocument(
       payload.documentId,
       payload.receiverEmails ?? undefined,
       reminderMessage,
     );
     return handleMcpResponse({
-      data: response,
+      data: documentResponse?.response?.data ?? documentResponse,
     });
   } catch (error: any) {
     return handleMcpError(error);

--- a/src/tools/documentsTools/sendReminderForDocumentSign.ts
+++ b/src/tools/documentsTools/sendReminderForDocumentSign.ts
@@ -20,8 +20,7 @@ const SendReminderForDocumentSignSchema = z.object({
   message: commonSchema.OptionalStringSchema.describe(
     'Optional. Message to be sent in the reminder email. If not provided, the system will use a default reminder message.',
   ),
-  onBehalfOf: commonSchema.EmailSchema
-    .optional()
+  onBehalfOf: commonSchema.EmailSchema.optional()
     .nullable()
     .describe(
       'Optional. Email address of the sender when creating a document on their behalf. This email can be retrieved from the `behalfOf` property in the get document or list documents tool.',


### PR DESCRIPTION
1. The input schema of the revoke_document tool and the send_reminder_for_document_sign tool has been modified.
2. The code to handle the response from these tools have been modified to avoid null-pointer-exception and undefined-property exception.